### PR TITLE
Generate response from schema examples

### DIFF
--- a/apisprout.go
+++ b/apisprout.go
@@ -161,6 +161,19 @@ func getTypedExampleFromSchema(schema *openapi3.Schema) (interface{}, error) {
 	if schema.Example != nil {
 		return schema.Example, nil
 	}
+
+	if schema.Type == "array" {
+		example := []interface{}{}
+		if schema.Items != nil && schema.Items.Value != nil {
+			ex, err := getTypedExampleFromSchema(schema.Items.Value)
+			if err != nil {
+				return nil, fmt.Errorf("can't get example for array item")
+			}
+			example = append(example, ex)
+		}
+		return example, nil
+	}
+
 	if len(schema.Properties) > 0 {
 		example := map[string]interface{}{}
 		for k, v := range schema.Properties {

--- a/apisprout.go
+++ b/apisprout.go
@@ -162,6 +162,9 @@ func getTypedExampleFromSchema(schema *openapi3.Schema) (interface{}, error) {
 		return schema.Example, nil
 	}
 
+	if schema.Type == "boolean" {
+		return true, nil
+	}
 	if schema.Type == "string" {
 		return "string", nil
 	}

--- a/apisprout.go
+++ b/apisprout.go
@@ -162,6 +162,9 @@ func getTypedExampleFromSchema(schema *openapi3.Schema) (interface{}, error) {
 		return schema.Example, nil
 	}
 
+	if schema.Type == "integer" {
+		return 0, nil
+	}
 	if schema.Type == "boolean" {
 		return true, nil
 	}

--- a/apisprout.go
+++ b/apisprout.go
@@ -162,6 +162,9 @@ func getTypedExampleFromSchema(schema *openapi3.Schema) (interface{}, error) {
 		return schema.Example, nil
 	}
 
+	if schema.Type == "number" {
+		return 0, nil
+	}
 	if schema.Type == "integer" {
 		return 0, nil
 	}

--- a/apisprout.go
+++ b/apisprout.go
@@ -148,8 +148,30 @@ func getTypedExample(mt *openapi3.MediaType) (interface{}, error) {
 		return mt.Examples[selected].Value.Value, nil
 	}
 
-	// TODO: generate data from JSON schema, if available?
+	if mt.Schema != nil {
+		return getTypedExampleFromSchema(mt.Schema.Value)
+	}
+	// TODO: generate data from JSON schema, if no examples available?
 
+	return nil, ErrNoExample
+}
+
+// getTypedExampleFromSchema will return an example from a given schema
+func getTypedExampleFromSchema(schema *openapi3.Schema) (interface{}, error) {
+	if schema.Example != nil {
+		return schema.Example, nil
+	}
+	if len(schema.Properties) > 0 {
+		example := map[string]interface{}{}
+		for k, v := range schema.Properties {
+			ex, err := getTypedExampleFromSchema(v.Value)
+			if err != nil {
+				return nil, fmt.Errorf("can't get example for '%s'", k)
+			}
+			example[k] = ex
+		}
+		return example, nil
+	}
 	return nil, ErrNoExample
 }
 

--- a/apisprout.go
+++ b/apisprout.go
@@ -162,6 +162,9 @@ func getTypedExampleFromSchema(schema *openapi3.Schema) (interface{}, error) {
 		return schema.Example, nil
 	}
 
+	if schema.Type == "string" {
+		return "string", nil
+	}
 	if schema.Type == "array" {
 		example := []interface{}{}
 		if schema.Items != nil && schema.Items.Value != nil {

--- a/apisprout_test.go
+++ b/apisprout_test.go
@@ -130,6 +130,27 @@ var getTypedExampleTestDataEntries = []getTypedExampleTestData{
 			assert.Equal(t, `true`, s)
 		},
 	},
+	getTypedExampleTestData{
+		name: "IntegerSchemaWithoutExample",
+		generateInputSchema: func() *openapi3.Schema {
+			schema := openapi3.NewIntegerSchema()
+			return schema
+		},
+		validateResult: func(t *testing.T, s string) {
+			assert.Equal(t, `0`, s)
+		},
+	},
+	getTypedExampleTestData{
+		name: "IntegerSchemaWithExample",
+		generateInputSchema: func() *openapi3.Schema {
+			schema := openapi3.NewIntegerSchema()
+			schema.Example = 1
+			return schema
+		},
+		validateResult: func(t *testing.T, s string) {
+			assert.Equal(t, `1`, s)
+		},
+	},
 }
 
 func Test_GetTypedExampleTest(t *testing.T) {

--- a/apisprout_test.go
+++ b/apisprout_test.go
@@ -151,6 +151,29 @@ var getTypedExampleTestDataEntries = []getTypedExampleTestData{
 			assert.Equal(t, `1`, s)
 		},
 	},
+	getTypedExampleTestData{
+		name: "NumberSchemaWithoutExample",
+		generateInputSchema: func() *openapi3.Schema {
+			schema := openapi3.NewSchema()
+			schema.Type = "number"
+			return schema
+		},
+		validateResult: func(t *testing.T, s string) {
+			assert.Equal(t, `0`, s)
+		},
+	},
+	getTypedExampleTestData{
+		name: "NumberSchemaWithExample",
+		generateInputSchema: func() *openapi3.Schema {
+			schema := openapi3.NewSchema()
+			schema.Type = "number"
+			schema.Example = 1.1
+			return schema
+		},
+		validateResult: func(t *testing.T, s string) {
+			assert.Equal(t, `1.1`, s)
+		},
+	},
 }
 
 func Test_GetTypedExampleTest(t *testing.T) {

--- a/apisprout_test.go
+++ b/apisprout_test.go
@@ -120,6 +120,16 @@ var getTypedExampleTestDataEntries = []getTypedExampleTestData{
 			assert.Equal(t, `"string"`, s)
 		},
 	},
+	getTypedExampleTestData{
+		name: "BooleanSchema",
+		generateInputSchema: func() *openapi3.Schema {
+			schema := openapi3.NewBoolSchema()
+			return schema
+		},
+		validateResult: func(t *testing.T, s string) {
+			assert.Equal(t, `true`, s)
+		},
+	},
 }
 
 func Test_GetTypedExampleTest(t *testing.T) {
@@ -147,7 +157,7 @@ func Test_GetTypedExampleShouldReturnErrorIfCannotGetFullExample(t *testing.T) {
 	parameterSchema1.Example = "testvalue"
 
 	parameterSchema2 := openapi3.NewObjectSchema()
-	nestedParameterSchemaWithoutExample := openapi3.NewBoolSchema()
+	nestedParameterSchemaWithoutExample := openapi3.NewObjectSchema()
 	parameterSchema2.WithProperty("nestedProperty", nestedParameterSchemaWithoutExample)
 
 	schema.WithProperties(map[string]*openapi3.Schema{

--- a/apisprout_test.go
+++ b/apisprout_test.go
@@ -8,10 +8,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_GetTypedExampleFromExampleField(t *testing.T) {
+func Test_GetTypedExampleShouldGetFromExampleField(t *testing.T) {
 	exampleData := map[string]string{"name1": "value1", "name2": "value2"}
+
 	mediaType := openapi3.NewMediaType()
 	mediaType.WithExample("example1", exampleData)
+
 	selectedExample, err := getTypedExample(mediaType)
 	assert.Nil(t, err)
 
@@ -19,4 +21,73 @@ func Test_GetTypedExampleFromExampleField(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotEmpty(t, string(selectedExampleJSON))
 	assert.Equal(t, `{"name1":"value1","name2":"value2"}`, string(selectedExampleJSON))
+}
+
+func Test_GetTypedExampleShouldGetFromSchemaExampleField(t *testing.T) {
+	exampleData := map[string]string{"name1": "value1", "name2": "value2"}
+
+	schema := openapi3.NewSchema()
+	schema.Example = exampleData
+
+	mediaType := openapi3.NewMediaType()
+	mediaType.WithSchema(schema)
+
+	selectedExample, err := getTypedExample(mediaType)
+	assert.Nil(t, err)
+
+	selectedExampleJSON, err := json.Marshal(selectedExample)
+	assert.Nil(t, err)
+	assert.NotEmpty(t, string(selectedExampleJSON))
+	assert.Equal(t, `{"name1":"value1","name2":"value2"}`, string(selectedExampleJSON))
+}
+
+func Test_GetTypedExampleShouldGetFromSchemaPropertiesExampleField(t *testing.T) {
+	schema := openapi3.NewSchema()
+
+	parameterSchema1 := openapi3.NewStringSchema()
+	parameterSchema1.Example = "testvalue"
+
+	parameterSchema2 := openapi3.NewObjectSchema()
+	nestedParameterSchema := openapi3.NewBoolSchema()
+	nestedParameterSchema.Example = true
+	parameterSchema2.WithProperty("nestedProperty", nestedParameterSchema)
+
+	schema.WithProperties(map[string]*openapi3.Schema{
+		"name1": parameterSchema1,
+		"name2": parameterSchema2,
+	})
+
+	mediaType := openapi3.NewMediaType()
+	mediaType.WithSchema(schema)
+
+	selectedExample, err := getTypedExample(mediaType)
+	assert.Nil(t, err)
+
+	selectedExampleJSON, err := json.Marshal(selectedExample)
+	assert.Nil(t, err)
+	assert.NotEmpty(t, string(selectedExampleJSON))
+	assert.Equal(t, `{"name1":"testvalue","name2":{"nestedProperty":true}}`, string(selectedExampleJSON))
+}
+
+func Test_GetTypedExampleShouldReturnErrorIfCannotGetFullExample(t *testing.T) {
+	schema := openapi3.NewSchema()
+
+	parameterSchema1 := openapi3.NewStringSchema()
+	parameterSchema1.Example = "testvalue"
+
+	parameterSchema2 := openapi3.NewObjectSchema()
+	nestedParameterSchemaWithoutExample := openapi3.NewBoolSchema()
+	parameterSchema2.WithProperty("nestedProperty", nestedParameterSchemaWithoutExample)
+
+	schema.WithProperties(map[string]*openapi3.Schema{
+		"name1": parameterSchema1,
+		"name2": parameterSchema2,
+	})
+
+	mediaType := openapi3.NewMediaType()
+	mediaType.WithSchema(schema)
+
+	selectedExample, err := getTypedExample(mediaType)
+	assert.NotNil(t, err)
+	assert.Nil(t, selectedExample)
 }

--- a/apisprout_test.go
+++ b/apisprout_test.go
@@ -99,6 +99,27 @@ var getTypedExampleTestDataEntries = []getTypedExampleTestData{
 			assert.Equal(t, `[{"name1":"testvalue"}]`, s)
 		},
 	},
+	getTypedExampleTestData{
+		name: "StringSchemaWithExample",
+		generateInputSchema: func() *openapi3.Schema {
+			schema := openapi3.NewStringSchema()
+			schema.Example = "examplestr"
+			return schema
+		},
+		validateResult: func(t *testing.T, s string) {
+			assert.Equal(t, `"examplestr"`, s)
+		},
+	},
+	getTypedExampleTestData{
+		name: "StringSchemaWithoutExample",
+		generateInputSchema: func() *openapi3.Schema {
+			schema := openapi3.NewStringSchema()
+			return schema
+		},
+		validateResult: func(t *testing.T, s string) {
+			assert.Equal(t, `"string"`, s)
+		},
+	},
 }
 
 func Test_GetTypedExampleTest(t *testing.T) {

--- a/apisprout_test.go
+++ b/apisprout_test.go
@@ -69,6 +69,52 @@ func Test_GetTypedExampleShouldGetFromSchemaPropertiesExampleField(t *testing.T)
 	assert.Equal(t, `{"name1":"testvalue","name2":{"nestedProperty":true}}`, string(selectedExampleJSON))
 }
 
+func Test_GetTypedExampleShouldGetFromSchemaArrayItemsStringExampleField(t *testing.T) {
+	schema := openapi3.NewArraySchema()
+
+	itemSchema := openapi3.NewStringSchema()
+	itemSchema.Example = "testvalue"
+
+	schema.WithItems(itemSchema)
+
+	mediaType := openapi3.NewMediaType()
+	mediaType.WithSchema(schema)
+
+	selectedExample, err := getTypedExample(mediaType)
+	assert.Nil(t, err)
+
+	selectedExampleJSON, err := json.Marshal(selectedExample)
+	assert.Nil(t, err)
+	assert.NotEmpty(t, string(selectedExampleJSON))
+	assert.Equal(t, `["testvalue"]`, string(selectedExampleJSON))
+}
+
+func Test_GetTypedExampleShouldGetFromSchemaArrayItemsObjectExampleField(t *testing.T) {
+	schema := openapi3.NewArraySchema()
+
+	itemSchema := openapi3.NewObjectSchema()
+
+	parameterSchema1 := openapi3.NewStringSchema()
+	parameterSchema1.Example = "testvalue"
+
+	itemSchema.WithProperties(map[string]*openapi3.Schema{
+		"name1": parameterSchema1,
+	})
+
+	schema.WithItems(itemSchema)
+
+	mediaType := openapi3.NewMediaType()
+	mediaType.WithSchema(schema)
+
+	selectedExample, err := getTypedExample(mediaType)
+	assert.Nil(t, err)
+
+	selectedExampleJSON, err := json.Marshal(selectedExample)
+	assert.Nil(t, err)
+	assert.NotEmpty(t, string(selectedExampleJSON))
+	assert.Equal(t, `[{"name1":"testvalue"}]`, string(selectedExampleJSON))
+}
+
 func Test_GetTypedExampleShouldReturnErrorIfCannotGetFullExample(t *testing.T) {
 	schema := openapi3.NewSchema()
 

--- a/apisprout_test.go
+++ b/apisprout_test.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_GetTypedExampleFromExampleField(t *testing.T) {
+	exampleData := map[string]string{"name1": "value1", "name2": "value2"}
+	mediaType := openapi3.NewMediaType()
+	mediaType.WithExample("example1", exampleData)
+	selectedExample, err := getTypedExample(mediaType)
+	assert.Nil(t, err)
+
+	selectedExampleJSON, err := json.Marshal(selectedExample)
+	assert.Nil(t, err)
+	assert.NotEmpty(t, string(selectedExampleJSON))
+	assert.Equal(t, `{"name1":"value1","name2":"value2"}`, string(selectedExampleJSON))
+}


### PR DESCRIPTION
This pull request is the first step towards generating responses from schema.

If schema example field exists, it is returned and send as response.
If there are no schema example, the examples of properties are inspected to build response.