### PR TITLE
Add server url handling

### DIFF
--- a/apisprout.go
+++ b/apisprout.go
@@ -492,5 +492,7 @@ func server(cmd *cobra.Command, args []string) {
 	})
 
 	fmt.Printf("🌱 Sprouting %s on port %d\n", swagger.Info.Title, viper.GetInt("port"))
-	http.ListenAndServe(fmt.Sprintf(":%d", viper.GetInt("port")), nil)
+	if err := http.ListenAndServe(fmt.Sprintf(":%d", viper.GetInt("port")), nil); err != nil {
+		log.Fatal(err)
+	}
 }


### PR DESCRIPTION
Although servers and url is set, apisprout doesn't handle the base url.

for example, if we have this yaml, `http://localhost:8080/v1/foo` returns NotFound.

```
servers:
    - url: http://localhost:8080/v1/
paths:
  /foo:
    get:
      responses:
        '200':    # status code
          content:
            application/json:
              schema:
                    (snip...)
```

This is because `req *http.Request.URL` does not have a Hostname. see https://golang.org/pkg/net/http/#Request
And Hostname is required to `openapi3filter.Router.FindRoute` to handle servers.

This PR adds Hostname to the argument of `FindRoute()`.
