### PR TITLE
Prefer supports select specific example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ vendor
 logo.png
 apisprout*.zip
 apisprout*.xz
+.idea

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A simple, quick, cross-platform API mock server that returns examples specified 
   - Example: `Accept: application/*`
 - Prefer header to select response to test specific cases
   - Example: `Prefer: status=409`
+  - Example: `Prefer: status=200&example=successCase1`
 - Server name validation (enabled with `--validate-server`)
 - Request parameter & body validation (enabled with `--validate-request`)
 - Configuration via:

--- a/apisprout.go
+++ b/apisprout.go
@@ -229,7 +229,7 @@ func getTypedExampleFromSchema(schema *openapi3.Schema) (interface{}, error) {
 // getExample tries to return an example for a given operation.
 func getExample(negotiator *ContentNegotiator, prefer map[string][]string, op *openapi3.Operation) (int, string, interface{}, error) {
 	var responses []string
-	if prefer["status"][0] == "" {
+	if prefer["status"] == nil || prefer["status"][0] == "" {
 		// First, make a list of responses ordered by successful (200-299 status code)
 		// before other types.
 		success := make([]string, 0)


### PR DESCRIPTION
Make Prefer header supports selection for specific example

e.g.
curl -H "Prefer: status=200&example=success1" http://localhost:8000/users