### PR TITLE
Add jsonapi.org content-type

### DIFF
--- a/apisprout.go
+++ b/apisprout.go
@@ -460,7 +460,7 @@ func server(cmd *cobra.Command, args []string) {
 			encoded = example.([]byte)
 		} else {
 			switch mediatype {
-			case "application/json":
+			case "application/json", "application/vnd.api+json":
 				encoded, err = json.MarshalIndent(example, "", "  ")
 			case "application/x-yaml", "application/yaml", "text/x-yaml", "text/yaml", "text/vnd.yaml":
 				encoded, err = yaml.Marshal(example)


### PR DESCRIPTION
This adds the content type from https://jsonapi.org/#mime-types to make apisproug usable with JSON:API APIs.