### PR TITLE
Add support for allOf, anyOf, and oneOf

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -417,6 +417,67 @@ var schemaTests = []struct {
 		}`,
 		`{"normal": "string", "readOnly": "string"}`,
 	},
+	// ----- Combination keywords -----
+	{
+		"Combine with allOf",
+		`{
+			"allOf": [
+				{
+					"type": "object",
+					"properties": {
+						"foo": {"type": "string"}
+					}
+				},
+				{
+					"type": "object",
+					"properties": {
+						"bar": {"type": "boolean"}
+					}
+				}
+			]
+		}`,
+		`{"foo": "string", "bar": true}`,
+	},
+	{
+		"Combine with anyOf",
+		`{
+			"anyOf": [
+				{
+					"type": "object",
+					"properties": {
+						"foo": {"type": "string"}
+					}
+				},
+				{
+					"type": "object",
+					"properties": {
+						"bar": {"type": "boolean"}
+					}
+				}
+			]
+		}`,
+		`{"foo": "string"}`,
+	},
+	{
+		"Combine with oneOf",
+		`{
+			"oneOf": [
+				{
+					"type": "object",
+					"properties": {
+						"foo": {"type": "string"}
+					}
+				},
+				{
+					"type": "object",
+					"properties": {
+						"bar": {"type": "boolean"}
+					}
+				}
+			]
+		}`,
+		`{"foo": "string"}`,
+	},
 }
 
 func TestGenExample(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/danielgtaylor/apisprout
 go 1.12
 
 require (
-	github.com/davecgh/go-spew v1.1.1
 	github.com/fsnotify/fsnotify v1.4.7
 	github.com/getkin/kin-openapi v0.2.0
 	github.com/gobwas/glob v0.2.3


### PR DESCRIPTION
This change adds support for the `allOf`, `anyOf`, and `oneOf` keywords.

We ran into this issue internally and noticed that it had also been reported in #41. The scope of changes is relatively small, and we've included tests to demonstrate the improved behavior.

The only caveat is that the `allOf` processing only supports schemas that have `type: object` -- I couldn't think of a way that a scalar or array type could possibly work with it.

Let me know if you'd like any further changes or have any questions, and thank you for the very useful tool!