### PR TITLE
Add health check route

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,16 @@ Alternatively, you can use `go get`:
 go get github.com/danielgtaylor/apisprout
 ```
 
+## Extra Features
+
+### Remote Reload
+
+If your API spec is loaded from a remote URL, you can live-reload it by hitting the `/__reload` endpoint.
+
+### Health Check
+
+A simple endpoint which returns status code `200` is available at `/__health`. This endpoint successfully returns `200` even if `--validate-server` is turned on, and the endpoint is being accessed from a non-validated host.
+
 ## Contributing
 
 Contributions are very welcome. Please open a tracking issue or pull request and we can work to get things merged in.

--- a/apisprout.go
+++ b/apisprout.go
@@ -438,6 +438,12 @@ func server(cmd *cobra.Command, args []string) {
 		})
 	}
 
+	// Add a health check route which returns 200
+	http.HandleFunc("/__health", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		log.Printf("Health check")
+	})
+
 	// Register our custom HTTP handler that will use the router to find
 	// the appropriate OpenAPI operation and try to return an example.
 	http.HandleFunc("/", func(w http.ResponseWriter, req *http.Request) {


### PR DESCRIPTION
Create a route at `/__health` which just returns a `200` status code.

My reasoning for creating this was because AWS ALBs use an internal IP address as the "Host" when performing health checks. Using `apisprout` with the `--validate-server` flag was not allowing the health checks to pass, since the requests looked to be coming from an IP address instead of the hosted domain or localhost, and were therefore returning `... => Does not match any server`.

This new route returns `200` regardless regardless of `--validate-server` verifications.