### PR TITLE
Match any media type that seems like JSON or YAML

### DIFF
--- a/apisprout_test.go
+++ b/apisprout_test.go
@@ -1,12 +1,16 @@
 package main
 
 import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"reflect"
 	"testing"
 
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var localServerTests = []struct {
@@ -157,6 +161,94 @@ func TestParsePreferHeader(t *testing.T) {
 			if got := parsePreferHeader(tt.header); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("parsePreferHeader() = %v, want %v", got, tt.want)
 			}
+		})
+	}
+}
+
+func TestMediaTypes(t *testing.T) {
+	const schema = `{
+		"paths": {
+			"/test": {
+				"get": {
+					"summary": "Test",
+					"responses": {
+						"200": {
+							"content": {
+								"%s": {
+									"schema": {
+										type": "boolean",
+										"example": true
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}`
+
+	tests := []struct {
+		MediaType  string
+		StatusCode int
+	}{
+		{
+			MediaType:  "application/json",
+			StatusCode: http.StatusOK,
+		},
+		{
+			MediaType:  "application/vnd.test-api+json",
+			StatusCode: http.StatusOK,
+		},
+		{
+			MediaType:  "application/yaml",
+			StatusCode: http.StatusOK,
+		},
+		{
+			MediaType:  "application/x-yaml",
+			StatusCode: http.StatusOK,
+		},
+		{
+			MediaType:  "application/vnd.test-api+yaml",
+			StatusCode: http.StatusOK,
+		},
+		{
+			MediaType:  "text/yaml",
+			StatusCode: http.StatusOK,
+		},
+		{
+			MediaType:  "text/x-yaml",
+			StatusCode: http.StatusOK,
+		},
+		{
+			MediaType:  "text/vnd.test-api+yaml",
+			StatusCode: http.StatusOK,
+		},
+		{
+			MediaType:  "text/vnd.test-api+xml",
+			StatusCode: http.StatusInternalServerError,
+		},
+		{
+			MediaType:  "application/json-with-extensions",
+			StatusCode: http.StatusInternalServerError,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.MediaType, func(t *testing.T) {
+			_, router, err := load("file:///swagger.json", []byte(fmt.Sprintf(schema, test.MediaType)))
+			require.NoError(t, err)
+			require.NotNil(t, router)
+
+			rr := NewRefreshableRouter()
+			rr.Set(router)
+
+			req, err := http.NewRequest("GET", "/test", nil)
+			require.NoError(t, err)
+
+			resp := httptest.NewRecorder()
+			handler(rr).ServeHTTP(resp, req)
+
+			assert.Equal(t, test.StatusCode, resp.Code)
 		})
 	}
 }


### PR DESCRIPTION
This change modifies the media type matching to handle vendor-specific media types in addition to the standardized or well-known media types for JSON and YAML.

It additionally moves the HTTP handler out of the main server function and into its own variable, which we can then use `*httptest.ResponseRecorder` to test against.