### PR TITLE
add await header

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ If your API spec is loaded from a remote URL, you can live-reload it by hitting 
 
 A simple endpoint which returns status code `200` is available at `/__health`. This endpoint successfully returns `200` even if `--validate-server` is turned on, and the endpoint is being accessed from a non-validated host.
 
+### Response delay
+
+To set the response delay time, add the header "await". A format value is a standard Goland duration in string representation (e.g. "300ms").
+
 ## Contributing
 
 Contributions are very welcome. Please open a tracking issue or pull request and we can work to get things merged in.

--- a/apisprout.go
+++ b/apisprout.go
@@ -423,6 +423,18 @@ func mapContainsKey(dict map[string]string, key string) bool {
 
 var handler = func(rr *RefreshableRouter) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+
+		customAwait := req.Header.Get("await")
+		if customAwait != "" {
+			dur, err := time.ParseDuration(customAwait)
+			if err != nil {
+				log.Printf("ERROR: passed incorrect duration %s in await header", customAwait)
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			time.Sleep(dur)
+		}
+
 		if !viper.GetBool("disable-cors") {
 			corsOrigin := req.Header.Get("Origin")
 			if corsOrigin == "" {


### PR DESCRIPTION
Faced with a problem where it was necessary to emulate the delay of the response from the server. This new functionality closed the issue.